### PR TITLE
Fixing NullPointerException when running with Gradle 2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ configurations { jbehave }
 dependencies {
 	compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
 	testCompile (
-			[group: 'junit', name: 'junit', version: '4.+'],
+			[group: 'junit', name: 'junit', version: '4.11'],
 			[group: 'org.jbehave', name: 'jbehave-core', version: '4.+'],
-			[group: 'de.codecentric', name: 'jbehave-junit-runner', version: '1.0.1']
+			[group: 'de.codecentric', name: 'jbehave-junit-runner', version: '1.+']
 			)
 }
 


### PR DESCRIPTION
This is caused by the combination of jbehave-unit-runner 1.0.1 and the very latest beta of Junit (Which is what you get via 4.+).  Fixing Junit at 4.11 and jbehave-unit-runner at 1.1.2 (or leaving open at 1.+) fixes the problem.
